### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,5 +1,5 @@
-RGBLed   KEYWORD1
-setColors  KEYWORD2
-turnOn  KEYWORD2
-turnOff  KEYWORD2
-fadeTo  KEYWORD2
+RGBLed	KEYWORD1
+setColors	KEYWORD2
+turnOn	KEYWORD2
+turnOff	KEYWORD2
+fadeTo	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords